### PR TITLE
Switch from java.util.Date with synchronized formatting to Instant

### DIFF
--- a/src/main/java/com/chrisnewland/freelogj/Logger.java
+++ b/src/main/java/com/chrisnewland/freelogj/Logger.java
@@ -14,9 +14,8 @@ else
 package com.chrisnewland.freelogj;
 
 import java.io.PrintStream;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 public class Logger
 {
@@ -34,7 +33,7 @@ public class Logger
 		}
 	}
 
-	static final DateFormat DEFAULT_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+	static final DateTimeFormatter DEFAULT_DATE_FORMAT = DateTimeFormatter.ISO_INSTANT;
 
 	private static final String BRACES = "{}";
 
@@ -42,7 +41,7 @@ public class Logger
 
 	private final LogLevel logLevel;
 
-	private final DateFormat dateFormat;
+	private final DateTimeFormatter dateFormat;
 
 	private final PrintStream printStream;
 
@@ -61,12 +60,12 @@ public class Logger
 		return new Logger(clazz, logLevel, DEFAULT_DATE_FORMAT, printStream);
 	}
 
-	public static Logger getLogger(Class<?> clazz, LogLevel logLevel, DateFormat dateFormat, PrintStream printStream)
+	public static Logger getLogger(Class<?> clazz, LogLevel logLevel, DateTimeFormatter dateFormat, PrintStream printStream)
 	{
 		return new Logger(clazz, logLevel, dateFormat, printStream);
 	}
 
-	private Logger(Class<?> clazz, LogLevel logLevel, DateFormat dateFormat, PrintStream printStream)
+	private Logger(Class<?> clazz, LogLevel logLevel, DateTimeFormatter dateFormat, PrintStream printStream)
 	{
 		this.className = clazz.getName();
 		this.logLevel = logLevel;
@@ -143,10 +142,7 @@ public class Logger
 
 		StringBuilder builder = new StringBuilder();
 
-		synchronized (dateFormat)
-		{
-			builder.append(dateFormat.format(new Date(System.currentTimeMillis())));
-		}
+		builder.append(dateFormat.format(Instant.now()));
 
 		builder.append(logLevel.display).append(className).append(' ');
 

--- a/src/main/java/com/chrisnewland/freelogj/LoggerFactory.java
+++ b/src/main/java/com/chrisnewland/freelogj/LoggerFactory.java
@@ -6,7 +6,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.nio.file.Path;
-import java.text.DateFormat;
+import java.time.format.DateTimeFormatter;
 
 public class LoggerFactory
 {
@@ -14,7 +14,7 @@ public class LoggerFactory
 
 	private static PrintStream printStream = System.out;
 
-	private static DateFormat dateFormat = Logger.DEFAULT_DATE_FORMAT;
+	private static DateTimeFormatter dateFormat = Logger.DEFAULT_DATE_FORMAT;
 
 	public static void initialise(Logger.LogLevel logLevel)
 	{
@@ -27,7 +27,7 @@ public class LoggerFactory
 		LoggerFactory.printStream = printStream;
 	}
 
-	public static void initialise(Logger.LogLevel logLevel, PrintStream printStream, DateFormat dateFormat)
+	public static void initialise(Logger.LogLevel logLevel, PrintStream printStream, DateTimeFormatter dateFormat)
 	{
 		LoggerFactory.logLevel = logLevel;
 		LoggerFactory.printStream = printStream;


### PR DESCRIPTION
> Friends don't let friends use java.util.Date [(attribution)](https://www.oreilly.com/library/view/modern-java-recipes/9781491973165/ch08.html) 😉

Switching to Instant means logging will always be in UTC (which is handy for apps deployed across timezones)
and means we no longer need to synchronize around the formatting, as DateTimeFormatter is thread-safe