### PR TITLE
Add Supplier<String> based logger methods

### DIFF
--- a/src/main/java/com/chrisnewland/freelogj/Logger.java
+++ b/src/main/java/com/chrisnewland/freelogj/Logger.java
@@ -16,6 +16,7 @@ package com.chrisnewland.freelogj;
 import java.io.PrintStream;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.function.Supplier;
 
 public class Logger
 {
@@ -103,9 +104,19 @@ public class Logger
 		return true;
 	}
 
+	public void trace(Supplier<String> stringSupplier, Object... args)
+	{
+		log(LogLevel.TRACE, stringSupplier, args);
+	}
+
 	public void trace(String message, Object... args)
 	{
 		log(LogLevel.TRACE, message, args);
+	}
+
+	public void debug(Supplier<String> stringSupplier, Object... args)
+	{
+		log(LogLevel.DEBUG, stringSupplier, args);
 	}
 
 	public void debug(String message, Object... args)
@@ -113,9 +124,19 @@ public class Logger
 		log(LogLevel.DEBUG, message, args);
 	}
 
+	public void info(Supplier<String> stringSupplier, Object... args)
+	{
+		log(LogLevel.INFO, stringSupplier, args);
+	}
+
 	public void info(String message, Object... args)
 	{
 		log(LogLevel.INFO, message, args);
+	}
+
+	public void warn(Supplier<String> stringSupplier, Object... args)
+	{
+		log(LogLevel.WARN, stringSupplier, args);
 	}
 
 	public void warn(String message, Object... args)
@@ -123,14 +144,34 @@ public class Logger
 		log(LogLevel.WARN, message, args);
 	}
 
+	public void error(Supplier<String> stringSupplier, Object... args)
+	{
+		log(LogLevel.ERROR, stringSupplier, args);
+	}
+
 	public void error(String message, Object... args)
 	{
 		log(LogLevel.ERROR, message, args);
 	}
 
+	public void fatal(Supplier<String> stringSupplier, Object... args)
+	{
+		log(LogLevel.FATAL, stringSupplier, args);
+	}
+
 	public void fatal(String message, Object... args)
 	{
 		log(LogLevel.FATAL, message, args);
+	}
+
+	private void log(LogLevel logLevel, Supplier<String> stringSupplier, Object... args)
+	{
+		if (logLevel.level < this.logLevel.level)
+		{
+			return;
+		}
+
+		log(logLevel, stringSupplier.get(), args);
 	}
 
 	private void log(LogLevel logLevel, String message, Object... args)

--- a/src/test/java/com/chrisnewland/freelogj/LoggerTest.java
+++ b/src/test/java/com/chrisnewland/freelogj/LoggerTest.java
@@ -143,7 +143,7 @@ public class LoggerTest
 	{
 		Logger logger = Logger.getLogger(LoggerTest.class, logLevel, printStream);
 
-		logger.info(null);
+		logger.info((String)null);
 
 		checkContents("null");
 	}
@@ -343,5 +343,22 @@ public class LoggerTest
 		String contentsFromFile = new String(Files.readAllBytes(tempFile.toPath()));
 
 		assertTrue(contentsFromFile.endsWith("Name:Chris Newland Age:999 Location:QueingForCompilation\n"));
+	}
+
+	@Test
+	public void testSupplierLogging() throws Exception
+	{
+		Logger logger = Logger.getLogger(LoggerTest.class, logLevel, printStream);
+
+		// Below the log level, so won't get called
+		logger.debug(() -> { throw new RuntimeException("Nooooooo"); });
+
+		logger.error(() -> "something happened", new RuntimeException("oops"));
+
+		String contents = baos.toString();
+
+		assertFalse(contents.contains("Nooooooo"));
+		assertTrue(contents.contains("something happened"));
+		assertTrue(contents.contains("oops"));
 	}
 }


### PR DESCRIPTION
This means the caller doesn't need to check if the logger is enabled prior to doing
a long running log message calculation.  The calculation is only executed if the level
is high enough to be logged.

Feel free to ignore this if it adds unnecessary complication to the otherwise simple api